### PR TITLE
Backup and restore module - change initialization

### DIFF
--- a/kin-recovery/src/main/java/kin/recovery/AccountExtractor.java
+++ b/kin-recovery/src/main/java/kin/recovery/AccountExtractor.java
@@ -1,0 +1,25 @@
+package kin.recovery;
+
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
+import kin.sdk.KinAccount;
+import kin.sdk.KinClient;
+
+public class AccountExtractor {
+
+	@Nullable
+	public static KinAccount getKinAccount(KinClient kinClient, String publicAddress) {
+		KinAccount kinAccount = null;
+		if (kinClient != null && !TextUtils.isEmpty(publicAddress)) {
+			int numOfAccounts = kinClient.getAccountCount();
+			for (int i = 0; i < numOfAccounts; i++) {
+				KinAccount account = kinClient.getAccount(i);
+				if (account != null && account.getPublicAddress().equals(publicAddress)) {
+					kinAccount = account;
+					break;
+				}
+			}
+		}
+		return kinAccount;
+	}
+}

--- a/kin-recovery/src/main/java/kin/recovery/BackupManager.java
+++ b/kin-recovery/src/main/java/kin/recovery/BackupManager.java
@@ -6,8 +6,8 @@ import android.support.annotation.NonNull;
 import kin.recovery.events.BroadcastManagerImpl;
 import kin.recovery.events.CallbackManager;
 import kin.recovery.events.EventDispatcherImpl;
+import kin.recovery.events.InternalRestoreCallback;
 import kin.recovery.exception.BackupException;
-import kin.sdk.KinAccount;
 import kin.sdk.KinClient;
 
 public final class BackupManager {
@@ -48,9 +48,9 @@ public final class BackupManager {
 //		this.callbackManager.setBackupEvents(backupEvents);
 //	}
 
-	public void registerRestoreCallback(@NonNull final RestoreCallback<KinAccount> restoreCallback) {
+	public void registerRestoreCallback(@NonNull final RestoreCallback restoreCallback) {
 		Validator.checkNotNull(restoreCallback, "restoreCallback");
-		this.callbackManager.setRestoreCallback(new RestoreCallback<String>() {
+		this.callbackManager.setRestoreCallback(new InternalRestoreCallback() {
 
 			@Override
 			public void onSuccess(String publicAddress) {

--- a/kin-recovery/src/main/java/kin/recovery/BackupManager.java
+++ b/kin-recovery/src/main/java/kin/recovery/BackupManager.java
@@ -48,19 +48,14 @@ public final class BackupManager {
 //		this.callbackManager.setBackupEvents(backupEvents);
 //	}
 
-	public void registerRestoreCallback(@NonNull final RestoreCallback restoreCallback) {
+	public void registerRestoreCallback(@NonNull final RestoreCallback<KinAccount> restoreCallback) {
 		Validator.checkNotNull(restoreCallback, "restoreCallback");
-		this.callbackManager.setRestoreFinishCallback(new RestoreFinishCallback() {
+		this.callbackManager.setRestoreCallback(new RestoreCallback<String>() {
 
 			@Override
-			public void onRestoreFinishedSuccessfully(String publicAddress) {
-				restoreCallback.onSuccess(AccountExtractor.getKinAccount(kinClient, publicAddress));
-			}
-
-			@Override
-			public void onSuccess(KinAccount kinAccount) {
+			public void onSuccess(String publicAddress) {
 				// TODO A bit awkward because this method will never be called here. any suggestions regarding this interface?
-				restoreCallback.onSuccess(kinAccount);
+				restoreCallback.onSuccess(AccountExtractor.getKinAccount(kinClient, publicAddress));
 			}
 
 			@Override

--- a/kin-recovery/src/main/java/kin/recovery/BackupManager.java
+++ b/kin-recovery/src/main/java/kin/recovery/BackupManager.java
@@ -54,7 +54,6 @@ public final class BackupManager {
 
 			@Override
 			public void onSuccess(String publicAddress) {
-				// TODO A bit awkward because this method will never be called here. any suggestions regarding this interface?
 				restoreCallback.onSuccess(AccountExtractor.getKinAccount(kinClient, publicAddress));
 			}
 

--- a/kin-recovery/src/main/java/kin/recovery/Launcher.java
+++ b/kin-recovery/src/main/java/kin/recovery/Launcher.java
@@ -1,6 +1,10 @@
 package kin.recovery;
 
-
+import static kin.recovery.BackupManager.APP_ID_EXTRA;
+import static kin.recovery.BackupManager.NETWORK_PASSPHRASE_EXTRA;
+import static kin.recovery.BackupManager.NETWORK_URL_EXTRA;
+import static kin.recovery.BackupManager.PUBLIC_ADDRESS_EXTRA;
+import static kin.recovery.BackupManager.STORE_KEY_EXTRA;
 import static kin.recovery.events.CallbackManager.REQ_CODE_BACKUP;
 import static kin.recovery.events.CallbackManager.REQ_CODE_RESTORE;
 
@@ -9,21 +13,36 @@ import android.content.Intent;
 import android.support.annotation.NonNull;
 import kin.recovery.backup.view.BackupActivity;
 import kin.recovery.restore.view.RestoreActivity;
+import kin.sdk.KinClient;
 
 class Launcher {
 
 	private final Activity activity;
+	private final KinClient kinClient;
 
-	Launcher(@NonNull final Activity activity) {
+	Launcher(@NonNull final Activity activity, @NonNull final KinClient kinClient) {
 		this.activity = activity;
+		this.kinClient = kinClient;
 	}
 
-	void backupFlow() {
-		startForResult(new Intent(activity, BackupActivity.class), REQ_CODE_BACKUP);
+	void backupFlow(String publicAddress) {
+		Intent intent = new Intent(activity, BackupActivity.class);
+		addKinClientExtras(intent);
+		intent.putExtra(PUBLIC_ADDRESS_EXTRA, publicAddress);
+		startForResult(intent, REQ_CODE_BACKUP);
 	}
 
 	void restoreFlow() {
-		startForResult(new Intent(activity, RestoreActivity.class), REQ_CODE_RESTORE);
+		Intent intent = new Intent(activity, RestoreActivity.class);
+		addKinClientExtras(intent);
+		startForResult(intent, REQ_CODE_RESTORE);
+	}
+
+	private void addKinClientExtras(Intent intent) {
+		intent.putExtra(NETWORK_URL_EXTRA, kinClient.getEnvironment().getNetworkUrl());
+		intent.putExtra(NETWORK_PASSPHRASE_EXTRA, kinClient.getEnvironment().getNetworkPassphrase());
+		intent.putExtra(APP_ID_EXTRA, kinClient.getAppId());
+		intent.putExtra(STORE_KEY_EXTRA, kinClient.getStoreKey());
 	}
 
 	private void startForResult(@NonNull final Intent intent, final int reqCode) {

--- a/kin-recovery/src/main/java/kin/recovery/RestoreCallback.java
+++ b/kin-recovery/src/main/java/kin/recovery/RestoreCallback.java
@@ -1,10 +1,11 @@
 package kin.recovery;
 
 import kin.recovery.exception.BackupException;
+import kin.sdk.KinAccount;
 
 public interface RestoreCallback {
 
-	void onSuccess(int index);
+	void onSuccess(KinAccount kinAccount);
 
 	void onCancel();
 

--- a/kin-recovery/src/main/java/kin/recovery/RestoreCallback.java
+++ b/kin-recovery/src/main/java/kin/recovery/RestoreCallback.java
@@ -1,11 +1,10 @@
 package kin.recovery;
 
 import kin.recovery.exception.BackupException;
-import kin.sdk.KinAccount;
 
-public interface RestoreCallback {
+public interface RestoreCallback<T> {
 
-	void onSuccess(KinAccount kinAccount);
+	void onSuccess(T t);
 
 	void onCancel();
 

--- a/kin-recovery/src/main/java/kin/recovery/RestoreCallback.java
+++ b/kin-recovery/src/main/java/kin/recovery/RestoreCallback.java
@@ -1,10 +1,11 @@
 package kin.recovery;
 
 import kin.recovery.exception.BackupException;
+import kin.sdk.KinAccount;
 
-public interface RestoreCallback<T> {
+public interface RestoreCallback {
 
-	void onSuccess(T t);
+	void onSuccess(KinAccount kinAccount);
 
 	void onCancel();
 

--- a/kin-recovery/src/main/java/kin/recovery/RestoreFinishCallback.java
+++ b/kin-recovery/src/main/java/kin/recovery/RestoreFinishCallback.java
@@ -1,0 +1,7 @@
+package kin.recovery;
+
+public interface RestoreFinishCallback extends RestoreCallback {
+
+	void onRestoreFinishedSuccessfully(String publicAddress);
+
+}

--- a/kin-recovery/src/main/java/kin/recovery/RestoreFinishCallback.java
+++ b/kin-recovery/src/main/java/kin/recovery/RestoreFinishCallback.java
@@ -1,7 +1,0 @@
-package kin.recovery;
-
-public interface RestoreFinishCallback extends RestoreCallback {
-
-	void onRestoreFinishedSuccessfully(String publicAddress);
-
-}

--- a/kin-recovery/src/main/java/kin/recovery/backup/presenter/BackupPresenter.java
+++ b/kin-recovery/src/main/java/kin/recovery/backup/presenter/BackupPresenter.java
@@ -4,10 +4,13 @@ import android.os.Bundle;
 import kin.recovery.backup.view.BackupNavigator;
 import kin.recovery.backup.view.BackupView;
 import kin.recovery.base.BasePresenter;
+import kin.sdk.KinAccount;
 
 public interface BackupPresenter extends BasePresenter<BackupView>, BackupNavigator {
 
 	void onSaveInstanceState(Bundle outState);
 
 	void setAccountKey(String key);
+
+	KinAccount getKinAccount();
 }

--- a/kin-recovery/src/main/java/kin/recovery/backup/presenter/BackupPresenterImpl.java
+++ b/kin-recovery/src/main/java/kin/recovery/backup/presenter/BackupPresenterImpl.java
@@ -26,7 +26,7 @@ public class BackupPresenterImpl extends BasePresenterImpl<BackupView> implement
 	private String accountKey;
 
 
-	public BackupPresenterImpl(CallbackManager callbackManager, @NonNull KinAccount kinAccount,
+	public BackupPresenterImpl(@NonNull CallbackManager callbackManager, @NonNull KinAccount kinAccount,
 		@Nullable final Bundle savedInstanceState) {
 		this.callbackManager = callbackManager;
 		this.step = getStep(savedInstanceState);

--- a/kin-recovery/src/main/java/kin/recovery/backup/presenter/BackupPresenterImpl.java
+++ b/kin-recovery/src/main/java/kin/recovery/backup/presenter/BackupPresenterImpl.java
@@ -11,6 +11,7 @@ import android.support.annotation.Nullable;
 import kin.recovery.backup.view.BackupView;
 import kin.recovery.base.BasePresenterImpl;
 import kin.recovery.events.CallbackManager;
+import kin.sdk.KinAccount;
 
 public class BackupPresenterImpl extends BasePresenterImpl<BackupView> implements BackupPresenter {
 
@@ -20,13 +21,16 @@ public class BackupPresenterImpl extends BasePresenterImpl<BackupView> implement
 	private @Step
 	int step;
 	private final CallbackManager callbackManager;
+	private final KinAccount kinAccount;
 	private boolean isBackupSucceed = false;
 	private String accountKey;
 
 
-	public BackupPresenterImpl(CallbackManager callbackManager, @Nullable final Bundle savedInstanceState) {
+	public BackupPresenterImpl(CallbackManager callbackManager, @NonNull KinAccount kinAccount,
+		@Nullable final Bundle savedInstanceState) {
 		this.callbackManager = callbackManager;
 		this.step = getStep(savedInstanceState);
+		this.kinAccount = kinAccount;
 		this.accountKey = getAccountKey(savedInstanceState);
 	}
 
@@ -129,6 +133,11 @@ public class BackupPresenterImpl extends BasePresenterImpl<BackupView> implement
 	@Override
 	public void setAccountKey(String accountKey) {
 		this.accountKey = accountKey;
+	}
+
+	@Override
+	public KinAccount getKinAccount() {
+		return kinAccount;
 	}
 
 	@Override

--- a/kin-recovery/src/main/java/kin/recovery/backup/presenter/CreatePasswordPresenterImpl.java
+++ b/kin-recovery/src/main/java/kin/recovery/backup/presenter/CreatePasswordPresenterImpl.java
@@ -32,8 +32,7 @@ public class CreatePasswordPresenterImpl extends BasePresenterImpl<CreatePasswor
 		this.callbackManager = callbackManager;
 		this.callbackManager.sendBackupEvent(BACKUP_CREATE_PASSWORD_PAGE_VIEWED);
 		this.kinAccount = kinAccount;
-		this.pattern = Pattern
-			.compile("^(?=.*\\d)(?=.*[A-Z])(?=.*[!@#$%^&*()_+{}\\[\\]])(?!.*[^a-zA-Z0-9!@#$%^&*()_+{}\\[\\]])(.{9,})$");
+		this.pattern = getPattern();
 	}
 
 	@Override
@@ -140,6 +139,26 @@ public class CreatePasswordPresenterImpl extends BasePresenterImpl<CreatePasswor
 			view.enableNextButton();
 		}
 	}
+
+	private Pattern getPattern() {
+		String digit = "(?=.*\\d)";
+		String upper = "(?=.*[A-Z])";
+		String lower = "(?=.*[a-z])";
+		String special = "(?=.*[!@#$%^&*()_+{}\\[\\]])";
+		int min = 9;
+		int max = 20;
+		StringBuilder sb = new StringBuilder()
+			.append("^")
+			.append(digit)
+			.append(upper)
+			.append(lower)
+			.append(special)
+			.append("(.{")
+			.append(min).append(",")
+			.append(max).append("})$");
+		return Pattern.compile(sb.toString());
+	}
+
 
 	private boolean validatePassword(@NonNull final String password) {
 		Validator.checkNotNull(password, "password");

--- a/kin-recovery/src/main/java/kin/recovery/backup/view/CreatePasswordFragment.java
+++ b/kin-recovery/src/main/java/kin/recovery/backup/view/CreatePasswordFragment.java
@@ -43,7 +43,7 @@ public class CreatePasswordFragment extends Fragment implements CreatePasswordVi
 	private BackupNavigator nextStepListener;
 	private KeyboardHandler keyboardHandler;
 	private CreatePasswordPresenter createPasswordPresenter;
-	private KinAccount kinAccount; //TODO don't like the idea that it is here although no one use it because we only passing it to the presenter, any suggestions?
+	private KinAccount kinAccount;
 
 	private PasswordEditText enterPassEditText;
 	private PasswordEditText confirmPassEditText;

--- a/kin-recovery/src/main/java/kin/recovery/backup/view/CreatePasswordFragment.java
+++ b/kin-recovery/src/main/java/kin/recovery/backup/view/CreatePasswordFragment.java
@@ -15,7 +15,6 @@ import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
-import kin.recovery.BackupManager;
 import kin.recovery.R;
 import kin.recovery.backup.presenter.CreatePasswordPresenter;
 import kin.recovery.backup.presenter.CreatePasswordPresenterImpl;
@@ -25,14 +24,16 @@ import kin.recovery.events.BroadcastManagerImpl;
 import kin.recovery.events.CallbackManager;
 import kin.recovery.events.EventDispatcherImpl;
 import kin.recovery.widget.PasswordEditText;
+import kin.sdk.KinAccount;
 
 public class CreatePasswordFragment extends Fragment implements CreatePasswordView {
 
 	public static CreatePasswordFragment newInstance(@NonNull final BackupNavigator nextStepListener,
-		@NonNull final KeyboardHandler keyboardHandler) {
+		@NonNull final KeyboardHandler keyboardHandler, @NonNull KinAccount kinAccount) {
 		CreatePasswordFragment fragment = new CreatePasswordFragment();
 		fragment.setNextStepListener(nextStepListener);
 		fragment.setKeyboardHandler(keyboardHandler);
+		fragment.setKinAccount(kinAccount);
 		return fragment;
 	}
 
@@ -42,6 +43,7 @@ public class CreatePasswordFragment extends Fragment implements CreatePasswordVi
 	private BackupNavigator nextStepListener;
 	private KeyboardHandler keyboardHandler;
 	private CreatePasswordPresenter createPasswordPresenter;
+	private KinAccount kinAccount; //TODO don't like the idea that it is here although no one use it because we only passing it to the presenter, any suggestions?
 
 	private PasswordEditText enterPassEditText;
 	private PasswordEditText confirmPassEditText;
@@ -55,7 +57,7 @@ public class CreatePasswordFragment extends Fragment implements CreatePasswordVi
 		initViews(root);
 		createPasswordPresenter = new CreatePasswordPresenterImpl(
 			new CallbackManager(new EventDispatcherImpl(new BroadcastManagerImpl(getActivity()))), nextStepListener,
-			BackupManager.getKeyStoreProvider());
+			kinAccount);
 		createPasswordPresenter.onAttach(this);
 		return root;
 	}
@@ -139,6 +141,10 @@ public class CreatePasswordFragment extends Fragment implements CreatePasswordVi
 
 	public void setKeyboardHandler(KeyboardHandler keyboardHandler) {
 		this.keyboardHandler = keyboardHandler;
+	}
+
+	public void setKinAccount(KinAccount kinAccount) {
+		this.kinAccount = kinAccount;
 	}
 
 	private void openKeyboard(View view) {

--- a/kin-recovery/src/main/java/kin/recovery/events/CallbackManager.java
+++ b/kin-recovery/src/main/java/kin/recovery/events/CallbackManager.java
@@ -7,7 +7,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import kin.recovery.BackupCallback;
 import kin.recovery.BackupEvents;
-import kin.recovery.RestoreCallback;
 import kin.recovery.RestoreEvents;
 import kin.recovery.exception.BackupException;
 
@@ -16,7 +15,7 @@ public class CallbackManager {
 	@Nullable
 	private BackupCallback backupCallback;
 	@Nullable
-	private RestoreCallback restoreCallback;
+	private InternalRestoreCallback internalRestoreCallback;
 
 	private final EventDispatcher eventDispatcher;
 
@@ -40,8 +39,8 @@ public class CallbackManager {
 		this.backupCallback = backupCallback;
 	}
 
-	public void setRestoreCallback(@Nullable RestoreCallback restoreCallback) {
-		this.restoreCallback = restoreCallback;
+	public void setRestoreCallback(@Nullable InternalRestoreCallback internalRestoreCallback) {
+		this.internalRestoreCallback = internalRestoreCallback;
 	}
 
 	public void setBackupEvents(@Nullable BackupEvents backupEvents) {
@@ -55,7 +54,7 @@ public class CallbackManager {
 	public void unregisterCallbacksAndEvents() {
 		this.eventDispatcher.unregister();
 		this.backupCallback = null;
-		this.restoreCallback = null;
+		this.internalRestoreCallback = null;
 	}
 
 	public void onActivityResult(int requestCode, int resultCode, Intent data) {
@@ -81,26 +80,26 @@ public class CallbackManager {
 	}
 
 	private void handleRestoreResult(int resultCode, Intent data) {
-		if (restoreCallback != null) {
+		if (internalRestoreCallback != null) {
 			switch (resultCode) {
 				case RES_CODE_SUCCESS:
 					final String publicAddress = data.getStringExtra(EXTRA_KEY_PUBLIC_ADDRESS);
 					if (publicAddress == null) {
-						restoreCallback.onFailure(new BackupException(CODE_UNEXPECTED,
+						internalRestoreCallback.onFailure(new BackupException(CODE_UNEXPECTED,
 							"Unexpected error - imported account public address not found"));
 					}
-					restoreCallback.onSuccess(publicAddress);
+					internalRestoreCallback.onSuccess(publicAddress);
 					break;
 				case RES_CODE_CANCEL:
-					restoreCallback.onCancel();
+					internalRestoreCallback.onCancel();
 					break;
 				case RES_CODE_FAILED:
 					String errorMessage = data.getStringExtra(EXTRA_KEY_ERROR_MESSAGE);
 					int code = data.getIntExtra(EXTRA_KEY_ERROR_CODE, 0);
-					restoreCallback.onFailure(new BackupException(code, errorMessage));
+					internalRestoreCallback.onFailure(new BackupException(code, errorMessage));
 					break;
 				default:
-					restoreCallback.onFailure(
+					internalRestoreCallback.onFailure(
 						new BackupException(CODE_UNEXPECTED, "Unexpected error - unknown result code " + resultCode));
 					break;
 			}

--- a/kin-recovery/src/main/java/kin/recovery/events/CallbackManager.java
+++ b/kin-recovery/src/main/java/kin/recovery/events/CallbackManager.java
@@ -7,8 +7,8 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import kin.recovery.BackupCallback;
 import kin.recovery.BackupEvents;
+import kin.recovery.RestoreCallback;
 import kin.recovery.RestoreEvents;
-import kin.recovery.RestoreFinishCallback;
 import kin.recovery.exception.BackupException;
 
 public class CallbackManager {
@@ -16,7 +16,7 @@ public class CallbackManager {
 	@Nullable
 	private BackupCallback backupCallback;
 	@Nullable
-	private RestoreFinishCallback restoreFinishCallback;
+	private RestoreCallback restoreCallback;
 
 	private final EventDispatcher eventDispatcher;
 
@@ -40,8 +40,8 @@ public class CallbackManager {
 		this.backupCallback = backupCallback;
 	}
 
-	public void setRestoreFinishCallback(@Nullable RestoreFinishCallback restoreFinishCallback) {
-		this.restoreFinishCallback = restoreFinishCallback;
+	public void setRestoreCallback(@Nullable RestoreCallback restoreCallback) {
+		this.restoreCallback = restoreCallback;
 	}
 
 	public void setBackupEvents(@Nullable BackupEvents backupEvents) {
@@ -55,7 +55,7 @@ public class CallbackManager {
 	public void unregisterCallbacksAndEvents() {
 		this.eventDispatcher.unregister();
 		this.backupCallback = null;
-		this.restoreFinishCallback = null;
+		this.restoreCallback = null;
 	}
 
 	public void onActivityResult(int requestCode, int resultCode, Intent data) {
@@ -81,26 +81,26 @@ public class CallbackManager {
 	}
 
 	private void handleRestoreResult(int resultCode, Intent data) {
-		if (restoreFinishCallback != null) {
+		if (restoreCallback != null) {
 			switch (resultCode) {
 				case RES_CODE_SUCCESS:
 					final String publicAddress = data.getStringExtra(EXTRA_KEY_PUBLIC_ADDRESS);
 					if (publicAddress == null) {
-						restoreFinishCallback.onFailure(new BackupException(CODE_UNEXPECTED,
+						restoreCallback.onFailure(new BackupException(CODE_UNEXPECTED,
 							"Unexpected error - imported account public address not found"));
 					}
-					restoreFinishCallback.onRestoreFinishedSuccessfully(publicAddress);
+					restoreCallback.onSuccess(publicAddress);
 					break;
 				case RES_CODE_CANCEL:
-					restoreFinishCallback.onCancel();
+					restoreCallback.onCancel();
 					break;
 				case RES_CODE_FAILED:
 					String errorMessage = data.getStringExtra(EXTRA_KEY_ERROR_MESSAGE);
 					int code = data.getIntExtra(EXTRA_KEY_ERROR_CODE, 0);
-					restoreFinishCallback.onFailure(new BackupException(code, errorMessage));
+					restoreCallback.onFailure(new BackupException(code, errorMessage));
 					break;
 				default:
-					restoreFinishCallback.onFailure(
+					restoreCallback.onFailure(
 						new BackupException(CODE_UNEXPECTED, "Unexpected error - unknown result code " + resultCode));
 					break;
 			}

--- a/kin-recovery/src/main/java/kin/recovery/events/InternalRestoreCallback.java
+++ b/kin-recovery/src/main/java/kin/recovery/events/InternalRestoreCallback.java
@@ -1,0 +1,13 @@
+package kin.recovery.events;
+
+import kin.recovery.exception.BackupException;
+
+public interface InternalRestoreCallback {
+
+	void onSuccess(String publicAddress);
+
+	void onCancel();
+
+	void onFailure(BackupException throwable);
+
+}

--- a/kin-recovery/src/main/java/kin/recovery/restore/presenter/RestoreCompletedPresenter.java
+++ b/kin-recovery/src/main/java/kin/recovery/restore/presenter/RestoreCompletedPresenter.java
@@ -1,12 +1,9 @@
 package kin.recovery.restore.presenter;
 
 
-import android.os.Bundle;
 import kin.recovery.restore.view.RestoreCompletedView;
 
 public interface RestoreCompletedPresenter extends BaseChildPresenter<RestoreCompletedView> {
 
 	void close();
-
-	void onSaveInstanceState(Bundle outState);
 }

--- a/kin-recovery/src/main/java/kin/recovery/restore/presenter/RestoreCompletedPresenterImpl.java
+++ b/kin-recovery/src/main/java/kin/recovery/restore/presenter/RestoreCompletedPresenterImpl.java
@@ -1,18 +1,11 @@
 package kin.recovery.restore.presenter;
 
-
-import static kin.recovery.restore.presenter.RestorePresenterImpl.KEY_ACCOUNT_INDEX;
-
-import android.os.Bundle;
 import kin.recovery.restore.view.RestoreCompletedView;
 
 public class RestoreCompletedPresenterImpl extends BaseChildPresenterImpl<RestoreCompletedView> implements
 	RestoreCompletedPresenter {
 
-	private final int accountIndex;
-
-	public RestoreCompletedPresenterImpl(int accountIndex) {
-		this.accountIndex = accountIndex;
+	public RestoreCompletedPresenterImpl() {
 	}
 
 	@Override
@@ -22,11 +15,7 @@ public class RestoreCompletedPresenterImpl extends BaseChildPresenterImpl<Restor
 
 	@Override
 	public void close() {
-		getParentPresenter().closeFlow(accountIndex);
+		getParentPresenter().closeFlow();
 	}
 
-	@Override
-	public void onSaveInstanceState(Bundle outState) {
-		outState.putInt(KEY_ACCOUNT_INDEX, accountIndex);
-	}
 }

--- a/kin-recovery/src/main/java/kin/recovery/restore/presenter/RestorePresenter.java
+++ b/kin-recovery/src/main/java/kin/recovery/restore/presenter/RestorePresenter.java
@@ -5,18 +5,22 @@ import android.content.Intent;
 import android.os.Bundle;
 import kin.recovery.base.BasePresenter;
 import kin.recovery.restore.view.RestoreView;
+import kin.sdk.KinAccount;
+import kin.sdk.KinClient;
 
 public interface RestorePresenter extends BasePresenter<RestoreView> {
 
 	void navigateToEnterPasswordPage(final String accountKey);
 
-	void navigateToRestoreCompletedPage(final int accountIndex);
+	void navigateToRestoreCompletedPage(final KinAccount kinAccount);
 
-	void closeFlow(final int accountIndex);
+	void closeFlow();
 
 	void previousStep();
 
 	void onActivityResult(int requestCode, int resultCode, Intent data);
 
 	void onSaveInstanceState(Bundle outState);
+
+	KinClient getKinClient();
 }

--- a/kin-recovery/src/main/java/kin/recovery/restore/view/RestoreCompletedFragment.java
+++ b/kin-recovery/src/main/java/kin/recovery/restore/view/RestoreCompletedFragment.java
@@ -1,8 +1,5 @@
 package kin.recovery.restore.view;
 
-
-import static kin.recovery.restore.presenter.RestorePresenterImpl.KEY_ACCOUNT_INDEX;
-
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
@@ -20,14 +17,8 @@ public class RestoreCompletedFragment extends Fragment implements RestoreComplet
 
 	private RestoreCompletedPresenter presenter;
 
-	public static RestoreCompletedFragment newInstance(Integer accountIndex) {
-		RestoreCompletedFragment fragment = new RestoreCompletedFragment();
-		if (accountIndex != -1) {
-			Bundle bundle = new Bundle();
-			bundle.putInt(KEY_ACCOUNT_INDEX, accountIndex);
-			fragment.setArguments(bundle);
-		}
-		return fragment;
+	public static RestoreCompletedFragment newInstance() {
+		return new RestoreCompletedFragment();
 	}
 
 	@Nullable
@@ -36,8 +27,7 @@ public class RestoreCompletedFragment extends Fragment implements RestoreComplet
 		@Nullable Bundle savedInstanceState) {
 		View root = inflater.inflate(R.layout.kinrecovery_fragment_restore_completed, container, false);
 
-		int accountIndex = extractAccountIndex(savedInstanceState);
-		injectPresenter(accountIndex);
+		injectPresenter();
 		presenter.onAttach(this, ((RestoreActivity) getActivity()).getPresenter());
 
 		initToolbar();
@@ -45,26 +35,8 @@ public class RestoreCompletedFragment extends Fragment implements RestoreComplet
 		return root;
 	}
 
-	@Override
-	public void onSaveInstanceState(Bundle outState) {
-		presenter.onSaveInstanceState(outState);
-		super.onSaveInstanceState(outState);
-	}
-
-	private int extractAccountIndex(@Nullable Bundle savedInstanceState) {
-		Bundle bundle = savedInstanceState != null ? savedInstanceState : getArguments();
-		if (bundle == null) {
-			throw new IllegalStateException("Bundle is null, can't extract required accountIndex data.");
-		}
-		int accountIndex = bundle.getInt(KEY_ACCOUNT_INDEX, -1);
-		if (accountIndex == -1) {
-			throw new IllegalStateException("Can't find accountIndex data inside Bundle.");
-		}
-		return accountIndex;
-	}
-
-	private void injectPresenter(int accountIndex) {
-		presenter = new RestoreCompletedPresenterImpl(accountIndex);
+	private void injectPresenter() {
+		presenter = new RestoreCompletedPresenterImpl();
 	}
 
 	private void initToolbar() {

--- a/kin-recovery/src/main/java/kin/recovery/restore/view/RestoreEnterPasswordFragment.java
+++ b/kin-recovery/src/main/java/kin/recovery/restore/view/RestoreEnterPasswordFragment.java
@@ -15,7 +15,6 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
-import kin.recovery.BackupManager;
 import kin.recovery.R;
 import kin.recovery.backup.view.TextWatcherAdapter;
 import kin.recovery.backup.view.TextWatcherAdapter.TextChangeListener;
@@ -91,8 +90,7 @@ public class RestoreEnterPasswordFragment extends Fragment implements RestoreEnt
 
 	private void injectPresenter(String keystoreData) {
 		presenter = new RestoreEnterPasswordPresenterImpl(
-			new CallbackManager(new EventDispatcherImpl(new BroadcastManagerImpl(getActivity()))), keystoreData,
-			BackupManager.getKeyStoreProvider());
+			new CallbackManager(new EventDispatcherImpl(new BroadcastManagerImpl(getActivity()))), keystoreData);
 		presenter.onAttach(this, ((RestoreActivity) getActivity()).getPresenter());
 	}
 

--- a/kin-recovery/src/main/java/kin/recovery/restore/view/RestoreView.java
+++ b/kin-recovery/src/main/java/kin/recovery/restore/view/RestoreView.java
@@ -9,7 +9,7 @@ public interface RestoreView extends BaseView {
 
 	void navigateToEnterPassword(String keystoreData);
 
-	void navigateToRestoreCompleted(Integer data);
+	void navigateToRestoreCompleted();
 
 	void navigateBack();
 

--- a/kin-sdk/src/main/java/kin/sdk/KinClient.java
+++ b/kin-sdk/src/main/java/kin/sdk/KinClient.java
@@ -35,6 +35,7 @@ public class KinClient {
     private final GeneralBlockchainInfoRetrieverImpl generalBlockchainInfoRetriever;
     private final BlockchainEventsCreator blockchainEventsCreator;
     private final BackupRestore backupRestore;
+    private final String appId;
     private final String storeKey;
     @NonNull
     private final List<KinAccountImpl> kinAccounts = new ArrayList<>(1);
@@ -63,8 +64,9 @@ public class KinClient {
         this.environment = environment;
         this.backupRestore = new BackupRestoreImpl();
         Server server = initServer();
-        keyStore = initKeyStore(context.getApplicationContext(), storeKey);
+        this.appId = appId;
         this.storeKey = storeKey;
+        keyStore = initKeyStore(context.getApplicationContext(), storeKey);
         transactionSender = new TransactionSender(server, appId);
         accountInfoRetriever = new AccountInfoRetriever(server);
         generalBlockchainInfoRetriever = new GeneralBlockchainInfoRetrieverImpl(server);
@@ -75,7 +77,7 @@ public class KinClient {
     @VisibleForTesting
     KinClient(Environment environment, KeyStore keyStore, TransactionSender transactionSender,
         AccountInfoRetriever accountInfoRetriever, GeneralBlockchainInfoRetrieverImpl generalBlockchainInfoRetriever,
-        BlockchainEventsCreator blockchainEventsCreator, BackupRestore backupRestore, String storeKey) {
+        BlockchainEventsCreator blockchainEventsCreator, BackupRestore backupRestore, String appId, String storeKey) {
         this.environment = environment;
         this.keyStore = keyStore;
         this.transactionSender = transactionSender;
@@ -83,6 +85,7 @@ public class KinClient {
         this.generalBlockchainInfoRetriever = generalBlockchainInfoRetriever;
         this.blockchainEventsCreator = blockchainEventsCreator;
         this.backupRestore = backupRestore;
+        this.appId = appId;
         this.storeKey = storeKey;
         loadAccounts();
     }
@@ -238,6 +241,10 @@ public class KinClient {
      */
     public long getMinimumFeeSync() throws OperationFailedException {
         return generalBlockchainInfoRetriever.getMinimumFeeSync();
+    }
+
+    public String getAppId() {
+        return appId;
     }
 
     public String getStoreKey() {

--- a/kin-sdk/src/test/java/kin/sdk/KinClientTest.java
+++ b/kin-sdk/src/test/java/kin/sdk/KinClientTest.java
@@ -331,7 +331,7 @@ public class KinClientTest {
         Environment environment = new Environment(url, Environment.TEST.getNetworkPassphrase());
         kinClient = new KinClient(environment, fakeKeyStore, mockTransactionSender,
             mockAccountInfoRetriever, mockGeneralBlockchainInfoRetriever, mockBlockchainEventsCreator,
-            new FakeBackupRestore(), "");
+			new FakeBackupRestore(), APP_ID, "");
         Environment actualEnvironment = kinClient.getEnvironment();
 
         assertNotNull(actualEnvironment);
@@ -385,6 +385,6 @@ public class KinClientTest {
     private KinClient createNewKinClient() {
         return new KinClient(fakeEnvironment, fakeKeyStore, mockTransactionSender,
             mockAccountInfoRetriever, mockGeneralBlockchainInfoRetriever, mockBlockchainEventsCreator,
-            new FakeBackupRestore(), "");
+			new FakeBackupRestore(), APP_ID, "");
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,1 @@
 include ':sample', ':kin-sdk', 'kin-base', 'kin-recovery'
-project(":kin-base").projectDir = file("kin-base")
-project(":kin-sdk").projectDir = file("kin-sdk")


### PR DESCRIPTION
1.Change the BackupManager initialization so he will get the kinClient from the developers.
Also backup will now be called with publicAddress parameter.
And Remove the"Flow" word from backFlow and restoreFlow API methods
2. Now RestoreCallback onSuccess will return the kinAccount.
3. Remove the registration for events from BackupManger until we decide with Ayelet about BI.
4. In BackupActivity and RestoreActivity we parse the intent extras and from them creating the KinClient
and KinAccount. Also persist them so they will survive activity restart.
5. Add getters for storeKey and for appId in KinClient
6. Remove from the presenter anything relating to account index and instead use kinClient and/or KinAccount,
Also remove anything relating to KeyStoreProvider because now everything is done internally.
7. In CallbackManager and BackupManager, added an interface which work as a mediator in order to get the KinAccount from the public address and then send it through onSuccess
8.  Fix the pattern for the password.