### PR TITLE
Allow empty memo

### DIFF
--- a/kin-sdk/kin-sdk-lib/src/androidTest/java/kin/sdk/AppIdTest.java
+++ b/kin-sdk/kin-sdk-lib/src/androidTest/java/kin/sdk/AppIdTest.java
@@ -1,0 +1,74 @@
+package kin.sdk;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static kin.sdk.IntegConsts.TEST_NETWORK_ID;
+import static kin.sdk.IntegConsts.TEST_NETWORK_URL;
+
+import android.support.test.InstrumentationRegistry;
+import android.util.Log;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+public class AppIdTest {
+
+    private static final String APP_ID = "1a2c";
+    private static final String STORE_KEY_TEST = "test";
+
+    private KinClient createNewKinClient(String appId) {
+        return new KinClient(InstrumentationRegistry.getTargetContext(),
+            new Environment(TEST_NETWORK_URL, TEST_NETWORK_ID),
+            appId,
+            STORE_KEY_TEST);
+    }
+
+    @Test
+    public void create_with_appId_is_valid() {
+        boolean failed = false;
+        try {
+            createNewKinClient(APP_ID);
+        } catch (IllegalArgumentException e) {
+            failed = true;
+        }
+        assertFalse(failed);
+    }
+
+    @Test
+    public void create_with_null_appId_is_valid() {
+        boolean failed = false;
+        try {
+            createNewKinClient(null);
+        } catch (IllegalArgumentException e) {
+            failed = true;
+        }
+        assertFalse(failed);
+    }
+
+    @Test
+    public void create_with_empty_string_appId_is_valid() {
+        boolean failed = false;
+        try {
+            createNewKinClient("");
+        } catch (IllegalArgumentException e) {
+            failed = true;
+        }
+        assertFalse(failed);
+    }
+
+    @Test
+    public void create_with_invalid_appId_throws() {
+
+        String[] invalidIds = new String[] {"A", "AB", "1", "a2", "ab", "$#", "$#@"};
+
+        for (int i = 0 ; i < invalidIds.length ; i++) {
+            boolean failed = false;
+            try {
+                createNewKinClient(invalidIds[i]);
+            } catch (IllegalArgumentException e) {
+                failed = true;
+            }
+            assertTrue(failed);
+        }
+    }
+}

--- a/kin-sdk/kin-sdk-lib/src/androidTest/java/kin/sdk/AppIdTest.java
+++ b/kin-sdk/kin-sdk-lib/src/androidTest/java/kin/sdk/AppIdTest.java
@@ -9,9 +9,14 @@ import android.support.test.InstrumentationRegistry;
 import android.util.Log;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class AppIdTest {
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
 
     private static final String APP_ID = "1a2c";
     private static final String STORE_KEY_TEST = "test";
@@ -25,13 +30,7 @@ public class AppIdTest {
 
     @Test
     public void create_with_appId_is_valid() {
-        boolean failed = false;
-        try {
-            createNewKinClient(APP_ID);
-        } catch (IllegalArgumentException e) {
-            failed = true;
-        }
-        assertFalse(failed);
+        createNewKinClient(APP_ID);
     }
 
     @Test
@@ -59,12 +58,12 @@ public class AppIdTest {
     @Test
     public void create_with_invalid_appId_throws() {
 
-        String[] invalidIds = new String[] {"A", "AB", "1", "a2", "ab", "$#", "$#@"};
+        String[] invalidIds = new String[] {"A", "AB", "1", "a2", "ab", "$#", "$#@", "A?BC"};
 
-        for (int i = 0 ; i < invalidIds.length ; i++) {
+        for (String invalidId : invalidIds) {
             boolean failed = false;
             try {
-                createNewKinClient(invalidIds[i]);
+                createNewKinClient(invalidId);
             } catch (IllegalArgumentException e) {
                 failed = true;
             }

--- a/kin-sdk/kin-sdk-lib/src/androidTest/kotlin/kin/sdk/KinAccountIntegrationTest.kt
+++ b/kin-sdk/kin-sdk-lib/src/androidTest/kotlin/kin/sdk/KinAccountIntegrationTest.kt
@@ -3,6 +3,7 @@ package kin.sdk
 import android.support.test.InstrumentationRegistry
 import android.support.test.filters.LargeTest
 import kin.base.Memo
+import kin.base.MemoNone
 import kin.base.MemoText
 import kin.base.Server
 import kin.sdk.IntegConsts.TEST_NETWORK_URL
@@ -110,23 +111,59 @@ class KinAccountIntegrationTest {
         val memo = "fake memo"
         val expectedMemo = addAppIdToMemo(memo)
 
-        val latch = CountDownLatch(1)
-        val listenerRegistration = kinAccountReceiver.addPaymentListener { _ -> latch.countDown() }
-
-        val transaction = kinAccountSender.buildTransactionSync(kinAccountReceiver.publicAddress.orEmpty(),
-                BigDecimal("21.123"), fee, memo)
-        val transactionId = kinAccountSender.sendTransactionSync(transaction)
-        assertThat(kinAccountSender.balanceSync.value(), equalTo(BigDecimal("78.87700").subtract(feeInKin)))
-        assertThat(kinAccountReceiver.balanceSync.value(), equalTo(BigDecimal("21.12300")))
-
-        assertTrue(latch.await(timeoutDurationSeconds, TimeUnit.SECONDS))
-        listenerRegistration.remove()
+        val transactionId = sendTransactionAndAssert(kinAccountSender, kinAccountReceiver, memo)
 
         val server = Server(TEST_NETWORK_URL)
         val transactionResponse = server.transactions().transaction(transactionId.id())
         val actualMemo = transactionResponse.memo
-        assertThat<Memo>(actualMemo, `is`<Memo>(instanceOf<Memo>(MemoText::class.java)))
+        assertTrue { actualMemo is MemoText }
         assertThat((actualMemo as MemoText).text, equalTo(expectedMemo))
+    }
+
+    @Test
+    @LargeTest
+    @Throws(Exception::class)
+    fun sendTransaction_WithoutMemoJustPrefix() {
+        val (kinAccountSender, kinAccountReceiver) = onboardAccounts(senderFundAmount = 100)
+        val expectedMemo = addAppIdToMemo("")
+        val transactionId = sendTransactionAndAssert(kinAccountSender, kinAccountReceiver, null)
+        val server = Server(TEST_NETWORK_URL)
+        val transactionResponse = server.transactions().transaction(transactionId.id())
+        val actualMemo = transactionResponse.memo
+        assertTrue { actualMemo is MemoText }
+        assertThat((actualMemo as MemoText).text, equalTo(expectedMemo))
+    }
+
+    @Test
+    @LargeTest
+    @Throws(Exception::class)
+    fun sendTransaction_WithoutMemo() {
+        val (kinAccountSender, kinAccountReceiver) = onboardAccounts(
+                senderFundAmount = 100,
+                kinClient = KinClient(InstrumentationRegistry.getTargetContext(), environment, null))
+
+        val transactionId = sendTransactionAndAssert(kinAccountSender, kinAccountReceiver, null)
+        val server = Server(TEST_NETWORK_URL)
+        val transactionResponse = server.transactions().transaction(transactionId.id())
+        val actualMemo = transactionResponse.memo
+        assertTrue { actualMemo is MemoNone }
+    }
+
+    @Test
+    @LargeTest
+    @Throws(Exception::class)
+    fun sendTransaction_WithoutMemoPrefix() {
+        val (kinAccountSender, kinAccountReceiver) = onboardAccounts(
+                senderFundAmount = 100,
+                kinClient = KinClient(InstrumentationRegistry.getTargetContext(), environment, null))
+
+        val memo = "fake memo"
+        val transactionId = sendTransactionAndAssert(kinAccountSender, kinAccountReceiver, memo)
+        val server = Server(TEST_NETWORK_URL)
+        val transactionResponse = server.transactions().transaction(transactionId.id())
+        val actualMemo = transactionResponse.memo
+        assertThat<Memo>(actualMemo, `is`<Memo>(instanceOf<Memo>(MemoText::class.java)))
+        assertThat((actualMemo as MemoText).text, equalTo(memo))
     }
 
     @Test
@@ -241,20 +278,9 @@ class KinAccountIntegrationTest {
     @Throws(Exception::class)
     fun sendTransaction_Success() {
         val (kinAccountSender, kinAccountReceiver) = onboardAccounts(senderFundAmount = 100)
-
-        val latch = CountDownLatch(1)
-        val listenerRegistration = kinAccountReceiver.addPaymentListener { _ -> latch.countDown() }
-
-        val transaction = kinAccountSender.buildTransactionSync(kinAccountReceiver.publicAddress.orEmpty(),
-                BigDecimal("21.123"), fee)
-        val transactionId = kinAccountSender.sendTransactionSync(transaction)
-        assertThat(kinAccountSender.balanceSync.value(), equalTo(BigDecimal("78.87700").subtract(feeInKin)))
-        assertThat(kinAccountReceiver.balanceSync.value(), equalTo(BigDecimal("21.12300")))
+        val transactionId = sendTransactionAndAssert(kinAccountSender, kinAccountReceiver, "fake memo")
         assertNotNull(transactionId)
         assertThat(transactionId.id(), not(isEmptyString()))
-
-        assertTrue(latch.await(timeoutDurationSeconds, TimeUnit.SECONDS))
-        listenerRegistration.remove()
     }
 
     @Test
@@ -352,7 +378,8 @@ class KinAccountIntegrationTest {
     }
 
     private fun onboardAccounts(senderFundAmount: Int = 0,
-                                receiverFundAmount: Int = 0): Pair<KinAccount, KinAccount> {
+                                receiverFundAmount: Int = 0,
+                                kinClient: KinClient = this.kinClient): Pair<KinAccount, KinAccount> {
         val kinAccountSender = kinClient.addAccount()
         val kinAccountReceiver = kinClient.addAccount()
         fakeKinOnBoard.createAccount(kinAccountSender.publicAddress.orEmpty(), senderFundAmount)
@@ -362,6 +389,15 @@ class KinAccountIntegrationTest {
 
     private fun addAppIdToMemo(memo: String): String {
         return appIdVersionPrefix.plus("-").plus(appId).plus("-").plus(memo)
+    }
+
+    private fun sendTransactionAndAssert(kinAccountSender: KinAccount, kinAccountReceiver: KinAccount, memo: String?): TransactionId {
+        val transaction = kinAccountSender.buildTransactionSync(kinAccountReceiver.publicAddress.orEmpty(),
+                BigDecimal("21.123"), fee, memo)
+        val transactionId = kinAccountSender.sendTransactionSync(transaction)
+        assertThat(kinAccountSender.balanceSync.value(), equalTo(BigDecimal("78.87700").subtract(feeInKin)))
+        assertThat(kinAccountReceiver.balanceSync.value(), equalTo(BigDecimal("21.12300")))
+        return transactionId
     }
 
     companion object {

--- a/kin-sdk/kin-sdk-lib/src/androidTest/kotlin/kin/sdk/KinAccountIntegrationTest.kt
+++ b/kin-sdk/kin-sdk-lib/src/androidTest/kotlin/kin/sdk/KinAccountIntegrationTest.kt
@@ -116,7 +116,6 @@ class KinAccountIntegrationTest {
         val server = Server(TEST_NETWORK_URL)
         val transactionResponse = server.transactions().transaction(transactionId.id())
         val actualMemo = transactionResponse.memo
-        assertTrue { actualMemo is MemoText }
         assertThat((actualMemo as MemoText).text, equalTo(expectedMemo))
     }
 
@@ -130,7 +129,6 @@ class KinAccountIntegrationTest {
         val server = Server(TEST_NETWORK_URL)
         val transactionResponse = server.transactions().transaction(transactionId.id())
         val actualMemo = transactionResponse.memo
-        assertTrue { actualMemo is MemoText }
         assertThat((actualMemo as MemoText).text, equalTo(expectedMemo))
     }
 

--- a/kin-sdk/kin-sdk-lib/src/main/java/kin/sdk/KinClient.java
+++ b/kin-sdk/kin-sdk-lib/src/main/java/kin/sdk/KinClient.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
+import android.util.Log;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -42,7 +43,7 @@ public class KinClient {
     private final List<KinAccountImpl> kinAccounts = new ArrayList<>(1);
 
     /**
-     * For more details please look at {@link #KinClient(Context context,Environment environment,String appId, String storeKey)}
+     * For more details please look at {@link #KinClient(Context context,Environment environment, String appId, String storeKey)}
      */
     public KinClient(@NonNull Context context, @NonNull Environment environment, String appId) {
         this(context, environment, appId,"");
@@ -117,8 +118,10 @@ public class KinClient {
     }
 
     private void validateAppId(String appId) {
-        checkNotEmpty(appId, "appId");
-        if (!appId.matches("[a-zA-Z0-9]{3,4}")) {
+        if (appId == null || appId.equals("")) {
+            Log.w("KinClient","WARNING: KinClient instance was created without a proper application ID. Is this what you intended to do?");
+        }
+        else if (!appId.matches("[a-zA-Z0-9]{3,4}")) {
             throw new IllegalArgumentException("appId must contain only upper and/or lower case letters and/or digits and that the total string length is between 3 to 4.\n" +
                     "for example 1234 or 2ab3 or cd2 or fqa, etc.");
         }

--- a/kin-sdk/kin-sdk-lib/src/main/java/kin/sdk/TransactionSender.java
+++ b/kin-sdk/kin-sdk-lib/src/main/java/kin/sdk/TransactionSender.java
@@ -49,7 +49,9 @@ class TransactionSender {
     Transaction buildTransaction(@NonNull KeyPair from, @NonNull String publicAddress, @NonNull BigDecimal amount,
                                  int fee, @Nullable String memo) throws OperationFailedException {
         checkParams(from, publicAddress, amount, fee, memo);
-        memo = addAppIdToMemo(memo);
+        if (appId != null && !appId.equals("")) {
+            memo = addAppIdToMemo(memo);
+        }
 
         KeyPair addressee = generateAddresseeKeyPair(publicAddress);
         AccountResponse sourceAccount = loadSourceAccount(from);


### PR DESCRIPTION
#### Main purpose (bug/feature/enhancement + description)
 You can now create KinClient instance without appId in order to remove the appId prefix on transactions memo.

When providing appId - the client will still perform validation on the content.

#### Technical details
Removed the appId is null/empty check when creating a new KinClient instance.

#### Tests (Unit/Integ)
- Added generic appId tests
- Added integration test to check the transaction memo in different appId senarios. 
- Removed some redundent asserts on KinAccount integration tests.

#### Documentation (Source/readme.md)
N/A