### PR TITLE
read integration tests network params from env variables

### DIFF
--- a/kin-sdk/kin-sdk-lib/build.gradle
+++ b/kin-sdk/kin-sdk-lib/build.gradle
@@ -24,6 +24,9 @@ android {
     buildTypes {
         debug {
             testCoverageEnabled true
+            buildConfigField "String", "INTEG_TESTS_NETWORK_FRIENDBOT", "\"$System.env.INTEG_TESTS_NETWORK_FRIENDBOT\""
+            buildConfigField "String", "INTEG_TESTS_NETWORK_PASSPHRASE", "\"$System.env.INTEG_TESTS_NETWORK_PASSPHRASE\""
+            buildConfigField "String", "INTEG_TESTS_NETWORK_URL", "\"$System.env.INTEG_TESTS_NETWORK_URL\""
         }
     }
 

--- a/kin-sdk/kin-sdk-lib/build.gradle
+++ b/kin-sdk/kin-sdk-lib/build.gradle
@@ -24,9 +24,9 @@ android {
     buildTypes {
         debug {
             testCoverageEnabled true
-            buildConfigField "String", "INTEG_TESTS_NETWORK_FRIENDBOT", "\"${System.getenv('INTEG_TESTS_NETWORK_FRIENDBOT1') ?: ""}\""
-            buildConfigField "String", "INTEG_TESTS_NETWORK_PASSPHRASE", "\"${System.getenv('INTEG_TESTS_NETWORK_PASSPHRASE1') ?: ""}\""
-            buildConfigField "String", "INTEG_TESTS_NETWORK_URL", "\"${System.getenv('INTEG_TESTS_NETWORK_URL1') ?: ""}\""
+            buildConfigField "String", "INTEG_TESTS_NETWORK_FRIENDBOT", "\"${System.getenv('INTEG_TESTS_NETWORK_FRIENDBOT') ?: ""}\""
+            buildConfigField "String", "INTEG_TESTS_NETWORK_PASSPHRASE", "\"${System.getenv('INTEG_TESTS_NETWORK_PASSPHRASE') ?: ""}\""
+            buildConfigField "String", "INTEG_TESTS_NETWORK_URL", "\"${System.getenv('INTEG_TESTS_NETWORK_URL') ?: ""}\""
         }
     }
 

--- a/kin-sdk/kin-sdk-lib/build.gradle
+++ b/kin-sdk/kin-sdk-lib/build.gradle
@@ -24,9 +24,9 @@ android {
     buildTypes {
         debug {
             testCoverageEnabled true
-            buildConfigField "String", "INTEG_TESTS_NETWORK_FRIENDBOT", "\"$System.env.INTEG_TESTS_NETWORK_FRIENDBOT\""
-            buildConfigField "String", "INTEG_TESTS_NETWORK_PASSPHRASE", "\"$System.env.INTEG_TESTS_NETWORK_PASSPHRASE\""
-            buildConfigField "String", "INTEG_TESTS_NETWORK_URL", "\"$System.env.INTEG_TESTS_NETWORK_URL\""
+            buildConfigField "String", "INTEG_TESTS_NETWORK_FRIENDBOT", "\"${System.getenv('INTEG_TESTS_NETWORK_FRIENDBOT1') ?: ""}\""
+            buildConfigField "String", "INTEG_TESTS_NETWORK_PASSPHRASE", "\"${System.getenv('INTEG_TESTS_NETWORK_PASSPHRASE1') ?: ""}\""
+            buildConfigField "String", "INTEG_TESTS_NETWORK_URL", "\"${System.getenv('INTEG_TESTS_NETWORK_URL1') ?: ""}\""
         }
     }
 

--- a/kin-sdk/kin-sdk-lib/src/androidTest/java/kin/sdk/IntegConsts.java
+++ b/kin-sdk/kin-sdk-lib/src/androidTest/java/kin/sdk/IntegConsts.java
@@ -3,9 +3,15 @@ package kin.sdk;
 
 final class IntegConsts {
 
-    static final String TEST_NETWORK_URL = BuildConfig.INTEG_TESTS_NETWORK_URL;
-    static final String TEST_NETWORK_ID = BuildConfig.INTEG_TESTS_NETWORK_PASSPHRASE;
-    static final String URL_CREATE_ACCOUNT = BuildConfig.INTEG_TESTS_NETWORK_FRIENDBOT + "?addr=%s&amount=%d";
-    static final String URL_FUND = BuildConfig.INTEG_TESTS_NETWORK_FRIENDBOT + "/fund?addr=%s&amount="; // faucet
-
+    static final String TEST_NETWORK_URL = BuildConfig.INTEG_TESTS_NETWORK_URL.isEmpty() ?
+            Environment.TEST.getNetworkUrl() : BuildConfig.INTEG_TESTS_NETWORK_URL;
+    static final String TEST_NETWORK_ID = BuildConfig.INTEG_TESTS_NETWORK_PASSPHRASE.isEmpty() ?
+            Environment.TEST.getNetworkPassphrase() : BuildConfig.INTEG_TESTS_NETWORK_PASSPHRASE;
+    static final String FRIENDBOT_URL = BuildConfig.INTEG_TESTS_NETWORK_FRIENDBOT.isEmpty() ?
+            "https://friendbot-testnet.kininfrastructure.com" : BuildConfig.INTEG_TESTS_NETWORK_FRIENDBOT;
+    static final String URL_CREATE_ACCOUNT = FRIENDBOT_URL + "?addr=%s&amount=%d";
+    static final String URL_FUND = FRIENDBOT_URL + "/fund?addr=%s&amount="; // faucet
+    static final String URL_WHITELISTING_SERVICE = (BuildConfig.INTEG_TESTS_NETWORK_FRIENDBOT.isEmpty() ?
+            "http://34.239.111.38:3000" : BuildConfig.INTEG_TESTS_NETWORK_FRIENDBOT)
+            + "/whitelist";
 }

--- a/kin-sdk/kin-sdk-lib/src/androidTest/java/kin/sdk/IntegConsts.java
+++ b/kin-sdk/kin-sdk-lib/src/androidTest/java/kin/sdk/IntegConsts.java
@@ -3,9 +3,9 @@ package kin.sdk;
 
 final class IntegConsts {
 
-    static final String TEST_NETWORK_URL = "https://horizon-testnet.kininfrastructure.com/";
-    static final String TEST_NETWORK_ID = "Kin Testnet ; December 2018";
-    static final String URL_CREATE_ACCOUNT = "https://friendbot.developers.kinecosystem.com?addr=%s&amount=%d";
-    static final String URL_FUND = "https://friendbot.developers.kinecosystem.com/fund?addr=%s&amount="; // faucet
+    static final String TEST_NETWORK_URL = BuildConfig.INTEG_TESTS_NETWORK_URL;
+    static final String TEST_NETWORK_ID = BuildConfig.INTEG_TESTS_NETWORK_PASSPHRASE;
+    static final String URL_CREATE_ACCOUNT = BuildConfig.INTEG_TESTS_NETWORK_FRIENDBOT + "?addr=%s&amount=%d";
+    static final String URL_FUND = BuildConfig.INTEG_TESTS_NETWORK_FRIENDBOT + "/fund?addr=%s&amount="; // faucet
 
 }

--- a/kin-sdk/kin-sdk-lib/src/androidTest/java/kin/sdk/WhitelistServiceForTest.java
+++ b/kin-sdk/kin-sdk-lib/src/androidTest/java/kin/sdk/WhitelistServiceForTest.java
@@ -13,7 +13,6 @@ import org.json.JSONObject;
 
 public class WhitelistServiceForTest {
 
-    private static final String URL_WHITELISTING_SERVICE = "http://34.239.111.38:3000/whitelist";
     private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
 
     private final OkHttpClient okHttpClient;
@@ -28,7 +27,7 @@ public class WhitelistServiceForTest {
     String whitelistTransaction(WhitelistableTransaction whitelistableTransaction) throws JSONException, IOException {
         RequestBody requestBody = RequestBody.create(JSON, toJson(whitelistableTransaction));
         okhttp3.Request request = new Request.Builder()
-                .url(URL_WHITELISTING_SERVICE)
+                .url(IntegConsts.URL_WHITELISTING_SERVICE)
                 .post(requestBody)
                 .build();
         Response response = okHttpClient.newCall(request).execute();

--- a/kin-sdk/kin-sdk-lib/src/androidTest/java/kin/sdk/WhitelistServiceForTest.java
+++ b/kin-sdk/kin-sdk-lib/src/androidTest/java/kin/sdk/WhitelistServiceForTest.java
@@ -1,14 +1,11 @@
 package kin.sdk;
 
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
+import android.util.Log;
+import okhttp3.*;
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import java.util.concurrent.TimeUnit;
 
 
 public class WhitelistServiceForTest {
@@ -24,16 +21,21 @@ public class WhitelistServiceForTest {
                 .build();
     }
 
-    String whitelistTransaction(WhitelistableTransaction whitelistableTransaction) throws JSONException, IOException {
+    String whitelistTransaction(WhitelistableTransaction whitelistableTransaction) throws Exception {
         RequestBody requestBody = RequestBody.create(JSON, toJson(whitelistableTransaction));
         okhttp3.Request request = new Request.Builder()
                 .url(IntegConsts.URL_WHITELISTING_SERVICE)
                 .post(requestBody)
                 .build();
         Response response = okHttpClient.newCall(request).execute();
-        String whitelist = null;
-        if (response.body() != null) {
+        String whitelist;
+        if (response.code() == 200 && response.body() != null) {
             whitelist = response.body().string();
+        } else {
+            String msg =
+                    "whitelistTransaction error, error code = " + response.code() + " message = " + response.body();
+            Log.d("test", msg);
+            throw new Exception(msg);
         }
         return whitelist;
     }


### PR DESCRIPTION
#### Main purpose (bug/feature/enhancement + description)
 We want to run integration testnet with controlled environment, which is a dedicated internal testnet
#### Technical details
Fetch integ network parameters from env variable, for making it configurable in CI level.
#### Tests (Unit/Integ)
Currently ran with public testnet, will change later when internal testnet will be ready.
#### Documentation (Source/readme.md)
N/A