### PR TITLE
DP-773 - log spamming

### DIFF
--- a/kin-sdk/kin-base/src/main/java/kin/base/responses/Response.java
+++ b/kin-sdk/kin-base/src/main/java/kin/base/responses/Response.java
@@ -7,9 +7,9 @@ public abstract class Response {
 
   public void setHeaders(String limit, String remaining, String reset) {
     try {
-        this.rateLimitLimit = Integer.parseInt(limit);
-        this.rateLimitRemaining = Integer.parseInt(remaining);
-        this.rateLimitReset = Integer.parseInt(reset);
+        this.rateLimitLimit = safeParse(limit);
+        this.rateLimitRemaining = safeParse(remaining);
+        this.rateLimitReset = safeParse(reset);
     } catch (Exception e) {
       e.printStackTrace();
     }


### PR DESCRIPTION
#### Main purpose (bug/feature/enhancement + description)
Kin blockchain might not add rate limit related headers, do not try to parse
and raise exception if not needed.
Should solve https://github.com/kinecosystem/kin-sdk-android/issues/54
#### Technical details
check for header existence before parsing
#### Tests (Unit/Integ)
N/A
#### Documentation (Source/readme.md)
N/A