### PR TITLE
We shouldn't need buildconfig urls for tests

### DIFF
--- a/kin-sdk/kin-sdk-lib/build.gradle
+++ b/kin-sdk/kin-sdk-lib/build.gradle
@@ -23,9 +23,6 @@ android {
     buildTypes {
         debug {
             testCoverageEnabled true
-            buildConfigField "String", "INTEG_TESTS_NETWORK_FRIENDBOT", "\"${System.getenv('INTEG_TESTS_NETWORK_FRIENDBOT') ?: ""}\""
-            buildConfigField "String", "INTEG_TESTS_NETWORK_PASSPHRASE", "\"${System.getenv('INTEG_TESTS_NETWORK_PASSPHRASE') ?: ""}\""
-            buildConfigField "String", "INTEG_TESTS_NETWORK_URL", "\"${System.getenv('INTEG_TESTS_NETWORK_URL') ?: ""}\""
         }
     }
 

--- a/kin-sdk/kin-sdk-lib/src/androidTest/java/kin/sdk/IntegConsts.java
+++ b/kin-sdk/kin-sdk-lib/src/androidTest/java/kin/sdk/IntegConsts.java
@@ -2,16 +2,10 @@ package kin.sdk;
 
 
 final class IntegConsts {
-
-    static final String TEST_NETWORK_URL = BuildConfig.INTEG_TESTS_NETWORK_URL.isEmpty() ?
-            Environment.TEST.getNetworkUrl() : BuildConfig.INTEG_TESTS_NETWORK_URL;
-    static final String TEST_NETWORK_ID = BuildConfig.INTEG_TESTS_NETWORK_PASSPHRASE.isEmpty() ?
-            Environment.TEST.getNetworkPassphrase() : BuildConfig.INTEG_TESTS_NETWORK_PASSPHRASE;
-    static final String FRIENDBOT_URL = BuildConfig.INTEG_TESTS_NETWORK_FRIENDBOT.isEmpty() ?
-            "https://friendbot-testnet.kininfrastructure.com" : BuildConfig.INTEG_TESTS_NETWORK_FRIENDBOT;
+    static final String TEST_NETWORK_URL = Environment.TEST.getNetworkUrl();
+    static final String TEST_NETWORK_ID = Environment.TEST.getNetworkPassphrase();
+    static final String FRIENDBOT_URL =  "https://friendbot-testnet.kininfrastructure.com";
     static final String URL_CREATE_ACCOUNT = FRIENDBOT_URL + "?addr=%s&amount=%d";
     static final String URL_FUND = FRIENDBOT_URL + "/fund?addr=%s&amount="; // faucet
-    static final String URL_WHITELISTING_SERVICE = (BuildConfig.INTEG_TESTS_NETWORK_FRIENDBOT.isEmpty() ?
-            "http://34.239.111.38:3000" : BuildConfig.INTEG_TESTS_NETWORK_FRIENDBOT)
-            + "/whitelist";
+    static final String URL_WHITELISTING_SERVICE = "http://34.239.111.38:3000/whitelist";
 }


### PR DESCRIPTION
We shouldn't need buildconfig urls to be different then when you run the tests locally.

#### Main purpose (bug/feature/enhancement + description)
 
#### Technical details

#### Tests (Unit/Integ)

#### Documentation (Source/readme.md)
