### PR TITLE
demo: fix onboarding testnet wallets

### DIFF
--- a/kin-backup-and-restore/kin-backup-and-restore-sample/src/main/java/kin/backupandrestore/sample/AccountCreator.java
+++ b/kin-backup-and-restore/kin-backup-and-restore-sample/src/main/java/kin/backupandrestore/sample/AccountCreator.java
@@ -20,8 +20,7 @@ import okhttp3.Response;
 public class AccountCreator {
 
     private static final double FUND_KIN_AMOUNT = 100;
-    private static final String URL_CREATE_ACCOUNT =
-            "https://friendbot.developers.kinecosystem.com?addr=%s&amount=" + String.valueOf(FUND_KIN_AMOUNT);
+    private static final String URL_CREATE_ACCOUNT = "https://friendbot-testnet.kininfrastructure.com?addr=%s&amount=" + String.valueOf(FUND_KIN_AMOUNT);
     private final OkHttpClient okHttpClient;
     private final Handler handler;
     private ListenerRegistration listenerRegistration;
@@ -74,6 +73,8 @@ public class AccountCreator {
                         response.close();
                         if (code != 200) {
                             fireOnFailure(callbacks, new Exception("Create account - response code is " + response.code()));
+                        } else {
+                            fireOnSuccess(callbacks);
                         }
                     }
                 });

--- a/kin-sdk/kin-sdk-sample/src/main/java/sdk/sample/OnBoarding.java
+++ b/kin-sdk/kin-sdk-sample/src/main/java/sdk/sample/OnBoarding.java
@@ -21,7 +21,9 @@ import okhttp3.Response;
 class OnBoarding {
 
     private static final int FUND_KIN_AMOUNT = 6000;
-    private static final String URL_CREATE_ACCOUNT = "https://friendbot.developers.kinecosystem.com?addr=%s&amount=" + String.valueOf(FUND_KIN_AMOUNT);
+    private static final String URL_CREATE_ACCOUNT = "https://friendbot-testnet.kininfrastructure.com?addr=%s&amount=" + String.valueOf(FUND_KIN_AMOUNT);
+
+
     private final OkHttpClient okHttpClient;
     private final Handler handler;
     private ListenerRegistration listenerRegistration;
@@ -74,6 +76,8 @@ class OnBoarding {
                         response.close();
                         if (code != 200) {
                             fireOnFailure(callbacks, new Exception("Create account - response code is " + response.code()));
+                        } else {
+                            fireOnSuccess(callbacks);
                         }
                     }
                 });


### PR DESCRIPTION
- the friendbot URL pointed to an inactive friendbot account
- success triggers were not firing causing a first-time use error prompt which should not have been shown